### PR TITLE
Feature/storage

### DIFF
--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -348,14 +348,19 @@ class CppGenerator:
 
         message_id_const = "static constexpr %s TYPE = %d;" % \
                            (MESSAGE_ID_C_TYPE, message_obj["id"])
+
         message_size_const = self.generate_static_size(data_type)
+        
         message_proto_id_const = "static constexpr %s PROTO = PROTO_ID;" % MESSAGE_PROTO_C_TYPE
+
+        message_has_dynamics = "static constexpr bool HAS_DYNAMICS = %s;" % str(data_type["has_dynamics"]).lower()
 
         self.start_block("struct " + message_obj["name"])
         self.extend([
             message_id_const,
             message_size_const,
             message_proto_id_const,
+            message_has_dynamics,
             ""
         ])
 
@@ -552,8 +557,6 @@ class CppGenerator:
 
         # Process dynamic fields
         for field in message["fields"][current_field_pos:]:
-            typeinfo = self._data_types_map[field["type"]]
-
             if field["type"] == "string":
                 if field["is_array"]:
                     raise MessgenException("Array of strings is not supported in C++ generator")
@@ -578,7 +581,7 @@ class CppGenerator:
         self.start_block("int parse_msg(const uint8_t *%s, uint32_t len, messgen::MemoryAllocator & %s)" %
                          (INPUT_BUF_NAME, INPUT_ALLOC_NAME))
 
-        if message["dynamic_fields_cnt"] == 0:
+        if not message["has_dynamics"]:
             self.append(ignore_variable(INPUT_ALLOC_NAME))
 
         if len(message["fields"]) == 0:

--- a/port/cpp/messgen/Storage.h
+++ b/port/cpp/messgen/Storage.h
@@ -6,32 +6,27 @@
 
 namespace messgen {
 
-template<class T, size_t SIZE=0, bool D = T::HAS_DYNAMICS>
-class Storage {};
-
 /**
  *  @brief Class for storing objects with dynamic fields.
  *          Owns memory for dynamic allocations.
  */
-template <class T, size_t SIZE>
-class Storage<T, SIZE, true> {
+template<class T>
+class StorageBase {
 public:
-    static_assert(SIZE != 0, "Storage size for message with dynamic fields has zero length!");
-
     static constexpr uint8_t TYPE = T::TYPE;
     static constexpr size_t STATIC_SIZE = T::STATIC_SIZE;
     static constexpr uint8_t PROTO = T::PROTO;
     static constexpr bool HAS_DYNAMICS = T::HAS_DYNAMICS;
 
-    Storage() {
-        std::cout << "Dynamic storage!" << std::endl;
-    }
+    StorageBase() noexcept = default;
 
-    explicit Storage(const T& value) noexcept:
-        _value(value) {}
+    virtual ~StorageBase() = default;
 
-    explicit Storage(const T&& value) noexcept:
-        _value(value) {}
+    explicit StorageBase(const T& value) noexcept:
+            _value(value) {}
+
+    explicit StorageBase(const T&& value) noexcept:
+            _value(value) {}
 
     bool operator== (const T& rhs) const noexcept {
         return _value == rhs;
@@ -49,12 +44,12 @@ public:
         return &_value;
     }
 
-    Storage& operator= (const T& rhs) noexcept {
+    StorageBase& operator= (const T& rhs) noexcept {
         _value = rhs;
         return *this;
     }
 
-    Storage& operator= (const T&& rhs) noexcept {
+    StorageBase& operator= (const T&& rhs) noexcept {
         _value = rhs;
         return *this;
     }
@@ -75,86 +70,64 @@ public:
         return _value.get_dynamic_size();
     }
 
-    int parse_msg(const uint8_t *buf, uint32_t len) noexcept {
-        return _value.parse_msg(buf, len, _memory_allocator);
-    }
-
     int serialize_msg(uint8_t *buf) const noexcept {
         return _value.serialize_msg(buf);
     }
 
+protected:
+    T _value;
+};
+
+template<class T, size_t SIZE=0, bool D = T::HAS_DYNAMICS>
+class Storage {};
+
+/**
+ *  @brief Class for storing objects with dynamic fields.
+ *          Owns memory for dynamic allocations.
+ */
+template <class T, size_t SIZE>
+class Storage<T, SIZE, true> : public StorageBase<T> {
+public:
+    static_assert(SIZE != 0, "Storage size for message with dynamic fields has zero length!");
+
+    Storage() noexcept = default;
+
+    explicit Storage(const T& value) noexcept:
+            StorageBase<T>(value) {}
+
+    explicit Storage(const T&& value) noexcept:
+            StorageBase<T>(value) {}
+
+    int parse_msg(const uint8_t *buf, uint32_t len) noexcept {
+        return this->_value.parse_msg(buf, len, _memory_allocator);
+    }
+
 private:
-    mutable T _value;
     StaticMemoryAllocator<SIZE> _memory_allocator;
 };
 
 /**
- *  @brief Class for storing objects without dynamic fields
+ *  @brief Class for storing objects with dynamic fields.
+ *          Owns memory for dynamic allocations.
  */
 template <class T, size_t SIZE>
-class Storage<T, SIZE, false> {
+class Storage<T, SIZE, false> : public StorageBase<T> {
 public:
     static_assert(SIZE == 0, "Storage for message without dynamic fields has non zero length!");
 
-    static constexpr uint8_t TYPE = T::TYPE;
-    static constexpr size_t STATIC_SIZE = T::STATIC_SIZE;
-    static constexpr uint8_t PROTO = T::PROTO;
-    static constexpr bool HAS_DYNAMICS = T::HAS_DYNAMICS;
-
-    Storage() {
-        std::cout << "Simple Storage" << std::endl;
-    }
+    Storage() noexcept = default;
 
     explicit Storage(const T& value) noexcept:
-            _value(value) {}
+            StorageBase<T>(value) {}
 
     explicit Storage(const T&& value) noexcept:
-            _value(value) {}
-
-    T* operator->() noexcept {
-        return &_value;
-    }
-
-    const T* operator->() const noexcept {
-        return &_value;
-    }
-
-    Storage& operator= (const T& rhs) noexcept {
-        _value = rhs;
-        return *this;
-    }
-
-    Storage& operator= (const T&& rhs) noexcept {
-        _value = rhs;
-        return *this;
-    }
-
-    operator T& () noexcept {
-        return _value;
-    }
-
-    operator const T& () const noexcept {
-        return _value;
-    }
-
-    size_t get_size() const noexcept {
-        return _value.get_size();
-    }
-
-    size_t get_dynamic_size() const noexcept {
-        return _value.get_dynamic_size();
-    }
+            StorageBase<T>(value) {}
 
     int parse_msg(const uint8_t *buf, uint32_t len) noexcept {
-        return _value.parse_msg(buf, len, _memory_allocator);
-    }
-
-    int serialize_msg(uint8_t *buf) const noexcept {
-        return _value.serialize_msg(buf);
+        return this->_value.parse_msg(buf, len, _memory_allocator);
     }
 
 private:
-    T _value;
     MemoryAllocator _memory_allocator{nullptr, 0};
 };
 

--- a/port/cpp/messgen/Storage.h
+++ b/port/cpp/messgen/Storage.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "MemoryAllocator.h"
+
+#include <iostream>
+
+namespace messgen {
+
+template<class T, size_t SIZE=0, bool D = T::HAS_DYNAMICS>
+class Storage {};
+
+/**
+ *  @brief Class for storing objects with dynamic fields.
+ *          Owns memory for dynamic allocations.
+ */
+template <class T, size_t SIZE>
+class Storage<T, SIZE, true> {
+public:
+    static_assert(SIZE != 0, "Storage size for message with dynamic fields has zero length!");
+
+    static constexpr uint8_t TYPE = T::TYPE;
+    static constexpr size_t STATIC_SIZE = T::STATIC_SIZE;
+    static constexpr uint8_t PROTO = T::PROTO;
+    static constexpr bool HAS_DYNAMICS = T::HAS_DYNAMICS;
+
+    Storage() {
+        std::cout << "Dynamic storage!" << std::endl;
+    }
+
+    explicit Storage(const T& value) noexcept:
+        _value(value) {}
+
+    explicit Storage(const T&& value) noexcept:
+        _value(value) {}
+
+    bool operator== (const T& rhs) const noexcept {
+        return _value == rhs;
+    }
+
+    bool operator== (const T&& rhs) const noexcept {
+        return _value == rhs;
+    }
+
+    T* operator->() noexcept {
+        return &_value;
+    }
+
+    const T* operator->() const noexcept {
+        return &_value;
+    }
+
+    Storage& operator= (const T& rhs) noexcept {
+        _value = rhs;
+        return *this;
+    }
+
+    Storage& operator= (const T&& rhs) noexcept {
+        _value = rhs;
+        return *this;
+    }
+
+    operator T& () noexcept {
+        return _value;
+    }
+
+    operator const T& () const noexcept {
+        return _value;
+    }
+
+    size_t get_size() const noexcept {
+        return _value.get_size();
+    }
+
+    size_t get_dynamic_size() const noexcept {
+        return _value.get_dynamic_size();
+    }
+
+    int parse_msg(const uint8_t *buf, uint32_t len) noexcept {
+        return _value.parse_msg(buf, len, _memory_allocator);
+    }
+
+    int serialize_msg(uint8_t *buf) const noexcept {
+        return _value.serialize_msg(buf);
+    }
+
+private:
+    mutable T _value;
+    StaticMemoryAllocator<SIZE> _memory_allocator;
+};
+
+/**
+ *  @brief Class for storing objects without dynamic fields
+ */
+template <class T, size_t SIZE>
+class Storage<T, SIZE, false> {
+public:
+    static_assert(SIZE == 0, "Storage for message without dynamic fields has non zero length!");
+
+    static constexpr uint8_t TYPE = T::TYPE;
+    static constexpr size_t STATIC_SIZE = T::STATIC_SIZE;
+    static constexpr uint8_t PROTO = T::PROTO;
+    static constexpr bool HAS_DYNAMICS = T::HAS_DYNAMICS;
+
+    Storage() {
+        std::cout << "Simple Storage" << std::endl;
+    }
+
+    explicit Storage(const T& value) noexcept:
+            _value(value) {}
+
+    explicit Storage(const T&& value) noexcept:
+            _value(value) {}
+
+    T* operator->() noexcept {
+        return &_value;
+    }
+
+    const T* operator->() const noexcept {
+        return &_value;
+    }
+
+    Storage& operator= (const T& rhs) noexcept {
+        _value = rhs;
+        return *this;
+    }
+
+    Storage& operator= (const T&& rhs) noexcept {
+        _value = rhs;
+        return *this;
+    }
+
+    operator T& () noexcept {
+        return _value;
+    }
+
+    operator const T& () const noexcept {
+        return _value;
+    }
+
+    size_t get_size() const noexcept {
+        return _value.get_size();
+    }
+
+    size_t get_dynamic_size() const noexcept {
+        return _value.get_dynamic_size();
+    }
+
+    int parse_msg(const uint8_t *buf, uint32_t len) noexcept {
+        return _value.parse_msg(buf, len, _memory_allocator);
+    }
+
+    int serialize_msg(uint8_t *buf) const noexcept {
+        return _value.serialize_msg(buf);
+    }
+
+private:
+    T _value;
+    MemoryAllocator _memory_allocator{nullptr, 0};
+};
+
+}

--- a/port/cpp/messgen/stl.h
+++ b/port/cpp/messgen/stl.h
@@ -59,20 +59,6 @@ int serialize(const T &msg, std::vector<uint8_t> &buf) {
 }
 
 /**
- * @brief Parse message with std::vector as memory pool
- * @tparam T            -   message type
- * @param info          -   message info
- * @param msg           -   message to parse
- * @param memory_pool   -   memory pool
- * @return  0 in case of success, -1 in case of error
- */
-template<class T>
-inline int parse(const messgen::MessageInfo &info, T &msg,
-                 messgen::MemoryAllocator &allocator) {
-    return messgen::parse(info, msg, allocator);
-}
-
-/**
  * @brief Helper wrapper around std::vector. See messgen.h get_message_info().
  */
 inline int get_message_info(const std::vector<uint8_t> &buf, MessageInfo &info) {

--- a/tests/cpp/MessgenTest.h
+++ b/tests/cpp/MessgenTest.h
@@ -201,7 +201,7 @@ TEST_F(TestMessgen, PlainMessageTest) {
 
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, _simple_msg.TYPE);
-    ASSERT_EQ(messgen::stl::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_simple_msg, parsed_msg);
 }
 
@@ -215,7 +215,7 @@ TEST_F(TestMessgen, EmptyMessgenTest) {
 
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, _empty_msg.TYPE);
-    ASSERT_EQ(messgen::stl::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_empty_msg, parsed_msg);
 }
 
@@ -229,7 +229,7 @@ TEST_F(TestMessgen, NestedMessagesTest) {
 
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, embedded_message_d2::TYPE);
-    ASSERT_EQ(messgen::stl::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_embedded_d2_msg, parsed_msg);
 }
 
@@ -261,7 +261,7 @@ TEST_F(TestMessgen, MultipleMessagesSerializeParse) {
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, embedded_message_d1::TYPE);
 
-    ASSERT_EQ(messgen::stl::parse(msg_info, d1_parsed, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, d1_parsed, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_embedded_d1_msg, d1_parsed);
     compact(_ser_buf, msg_info.get_total_size());
 
@@ -275,7 +275,7 @@ TEST_F(TestMessgen, MultipleMessagesSerializeParse) {
     ASSERT_EQ(msg_info.msg_id, embedded_message_d2::TYPE);
 
     // Parse d2
-    ASSERT_EQ(messgen::stl::parse(msg_info, d2_parsed, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, d2_parsed, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_embedded_d2_msg, d2_parsed);
     compact(_ser_buf, msg_info.get_total_size());
 
@@ -283,7 +283,7 @@ TEST_F(TestMessgen, MultipleMessagesSerializeParse) {
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, simple_message::TYPE);
 
-    ASSERT_EQ(messgen::stl::parse(msg_info, simple_parsed, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, simple_parsed, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_simple_msg, simple_parsed);
 
     // All message parser -> slice must be empty.
@@ -303,7 +303,7 @@ TEST_F(TestMessgen, TestSimpleDynamicMessage) {
     ASSERT_EQ(msg_info.msg_id, simple_dynamic_message::TYPE);
 
     messgen::msgs::messgen_test::simple_dynamic_message parsed_simple_dyn_msg{};
-    ASSERT_EQ(messgen::stl::parse(msg_info, parsed_simple_dyn_msg, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, parsed_simple_dyn_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_simple_dynamic_msg, parsed_simple_dyn_msg);
 }
 
@@ -318,7 +318,7 @@ TEST_F(TestMessgen, TestEmbeddedDynamicMessage) {
 
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, embedded_dynamic_message_d1::TYPE);
-    ASSERT_EQ(messgen::stl::parse(msg_info, parsed_embedded_dyn_msg, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, parsed_embedded_dyn_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_embedded_dyn_d1_msg, parsed_embedded_dyn_msg);
 }
 
@@ -410,7 +410,7 @@ TEST_F(TestMessgen, UseOneExisting) {
     ASSERT_EQ(msg_info.msg_id, use_one_existing::TYPE);
 
     messgen::msgs::messgen_test::use_one_existing parsed_use_one_existing_msg{};
-    ASSERT_EQ(messgen::stl::parse(msg_info, parsed_use_one_existing_msg, _messgen_alloc), msg_info.size);
+    ASSERT_EQ(messgen::parse(msg_info, parsed_use_one_existing_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_use_one_existing, parsed_use_one_existing_msg);
 }
 

--- a/tests/cpp/MessgenTest.h
+++ b/tests/cpp/MessgenTest.h
@@ -107,12 +107,17 @@ protected:
     std::default_random_engine gen;
 
     template <class T>
-    void serialize_and_assert(const T & msg) {
-        size_t init_buf_size = _ser_buf.size();
-        int res = messgen::stl::serialize(msg, _ser_buf);
+    static void serialize_and_assert_to_vec(const T & msg, std::vector<uint8_t> &vec) {
+        size_t init_buf_size = vec.size();
+        int res = messgen::stl::serialize(msg, vec);
 
-        ASSERT_EQ(res, messgen::get_serialized_size(msg));        
-        ASSERT_EQ(_ser_buf.size(), init_buf_size + messgen::get_serialized_size(msg));
+        ASSERT_EQ(res, messgen::get_serialized_size(msg));
+        ASSERT_EQ(vec.size(), init_buf_size + messgen::get_serialized_size(msg));
+    }
+
+    template <class T>
+    void serialize_and_assert(const T & msg) {
+        serialize_and_assert_to_vec(msg, _ser_buf);
     }
 
     messgen::msgs::messgen_test::simple_dynamic_message gen_random_simple_dynamic_msg() {
@@ -192,10 +197,10 @@ TEST_F(TestMessgen, PlainMessageTest) {
     serialize_and_assert(_simple_msg);
 
     messgen::MessageInfo msg_info{};
+    messgen::msgs::messgen_test::simple_message parsed_msg{};
+
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, _simple_msg.TYPE);
-
-    messgen::msgs::messgen_test::simple_message parsed_msg{};
     ASSERT_EQ(messgen::stl::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_simple_msg, parsed_msg);
 }
@@ -206,10 +211,10 @@ TEST_F(TestMessgen, EmptyMessgenTest) {
     serialize_and_assert(_empty_msg);
 
     messgen::MessageInfo msg_info{};
+    messgen::msgs::messgen_test::empty parsed_msg{};
+
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, _empty_msg.TYPE);
-
-    messgen::msgs::messgen_test::empty parsed_msg{};
     ASSERT_EQ(messgen::stl::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_empty_msg, parsed_msg);
 }
@@ -220,10 +225,10 @@ TEST_F(TestMessgen, NestedMessagesTest) {
     serialize_and_assert(_embedded_d2_msg);
 
     messgen::MessageInfo msg_info{};
+    embedded_message_d2 parsed_msg{};
+
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, embedded_message_d2::TYPE);
-
-    embedded_message_d2 parsed_msg{};
     ASSERT_EQ(messgen::stl::parse(msg_info, parsed_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_embedded_d2_msg, parsed_msg);
 }
@@ -309,11 +314,10 @@ TEST_F(TestMessgen, TestEmbeddedDynamicMessage) {
     serialize_and_assert(_embedded_dyn_d1_msg);
 
     messgen::MessageInfo msg_info{};
+    messgen::msgs::messgen_test::embedded_dynamic_message_d1 parsed_embedded_dyn_msg{};
 
     ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
     ASSERT_EQ(msg_info.msg_id, embedded_dynamic_message_d1::TYPE);
-
-    messgen::msgs::messgen_test::embedded_dynamic_message_d1 parsed_embedded_dyn_msg{};
     ASSERT_EQ(messgen::stl::parse(msg_info, parsed_embedded_dyn_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_embedded_dyn_d1_msg, parsed_embedded_dyn_msg);
 }
@@ -408,4 +412,59 @@ TEST_F(TestMessgen, UseOneExisting) {
     messgen::msgs::messgen_test::use_one_existing parsed_use_one_existing_msg{};
     ASSERT_EQ(messgen::stl::parse(msg_info, parsed_use_one_existing_msg, _messgen_alloc), msg_info.size);
     ASSERT_EQ(_use_one_existing, parsed_use_one_existing_msg);
+}
+
+TEST_F(TestMessgen, StorageSerialization) {
+    using namespace messgen::msgs;
+
+    messgen_test::simple_message simple_msg{gen_random_simple_msg()};
+    messgen_test::simple_dynamic_message simple_dynamic_msg{gen_random_simple_dynamic_msg()};
+
+    messgen::Storage<messgen_test::simple_message> simple_storage{simple_msg};
+    messgen::Storage<messgen_test::simple_dynamic_message, 128> dynamic_storage{simple_dynamic_msg};
+
+    std::vector<std::uint8_t> vec1;
+    std::vector<std::uint8_t> vec2;
+    vec1.reserve(16384);
+    vec2.reserve(16384);
+
+    serialize_and_assert_to_vec(simple_msg, vec1);
+    serialize_and_assert_to_vec(simple_dynamic_msg, vec1);
+    serialize_and_assert_to_vec(simple_storage, vec2);
+    serialize_and_assert_to_vec(dynamic_storage, vec2);
+
+    ASSERT_EQ(vec1, vec2);
+}
+
+TEST_F(TestMessgen, StorageParseTest) {
+    using namespace messgen::msgs;
+
+    // Serialize messages
+    messgen_test::simple_message simple_msg{gen_random_simple_msg()};
+    messgen_test::simple_dynamic_message dynamic_msg{gen_random_simple_dynamic_msg()};
+
+    serialize_and_assert(simple_msg);
+    serialize_and_assert(dynamic_msg);
+
+    // Parse messages
+    messgen::MessageInfo msg_info{};
+    messgen::Storage<messgen_test::simple_message> simple_storage;
+    messgen::Storage<messgen_test::simple_dynamic_message, 128> dynamic_storage;
+
+    // Parse simple msg
+    ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
+    ASSERT_EQ(msg_info.msg_id, messgen_test::simple_message::TYPE);
+    ASSERT_EQ(messgen::parse(msg_info, simple_storage), msg_info.size);
+    ASSERT_EQ(simple_msg, simple_storage);
+    compact(_ser_buf, msg_info.get_total_size());
+
+    // Parse simple dynamic msg
+    ASSERT_EQ(messgen::stl::get_message_info(_ser_buf, msg_info), OK);
+    ASSERT_EQ(msg_info.msg_id, messgen_test::simple_dynamic_message::TYPE);
+    ASSERT_EQ(messgen::parse(msg_info, dynamic_storage), msg_info.size);
+    ASSERT_EQ(dynamic_msg, dynamic_storage);
+    compact(_ser_buf, msg_info.get_total_size());
+
+    // Validate that buffer is empty
+    ASSERT_EQ(_ser_buf.size(), 0);
 }


### PR DESCRIPTION
Add Storage class template. It is useful when:

-  You need to store incoming message which contains dynamic fields since it owns memory for dynamics allocations.
-  It will not recreate MemoryAllocator for messages without dynamic fields on each parse call.