### PR TITLE
data-type-preprocessor: fix module name for children types

### DIFF
--- a/messgen/utils.py
+++ b/messgen/utils.py
@@ -26,7 +26,11 @@ def in_types_map(types_map, typename):
 
 
 def get_module_name(norm_typename):
-    return ""
+    items = norm_typename.split('/')
+    if len(items) != 4:
+        return ""
+
+    return items[0] + "/" + items[2]
 
 
 def is_array(typename):


### PR DESCRIPTION
Не работала следующая конструкция, генератор не мог найти тип Message3

Message3:
    - field: uint8
    - ....

Message2:
    - field: Message 3

Messgage1:
     - field: Message2