### PR TITLE
Fix make_dynamic from std::vector

### DIFF
--- a/port/cpp/messgen/stl.h
+++ b/port/cpp/messgen/stl.h
@@ -78,7 +78,11 @@ size_t for_each_message(const std::vector<uint8_t> &payload, F &f) {
  */
 template<class T>
 Dynamic <T> make_dynamic(std::vector<T> &vec) {
-    return Dynamic<T>{&vec[0], vec.size()};
+    if (vec.empty()) {
+        return Dynamic<T>{nullptr, 0};
+    } else {
+        return Dynamic<T>{vec.data(), static_cast<uint32_t>(vec.size())};
+    }
 }
 
 /**


### PR DESCRIPTION
memcpy requires valid pointers for zero size arrays, however vector.data() or &vec[0] does not guarantee valid pointers for empty vector