### PR TITLE
cpp: add for_each method on Dynamic<uint8_t>

### DIFF
--- a/port/cpp/messgen/messgen.h
+++ b/port/cpp/messgen/messgen.h
@@ -117,4 +117,9 @@ size_t for_each_message(const uint8_t *data, size_t data_size, F& f) {
     return buf - data;
 }
 
+template <class F>
+size_t for_each_message(const messgen::Dynamic<uint8_t> &message, F && f) {
+    return for_each_message(message.ptr, message.size, f);
+}
+
 }


### PR DESCRIPTION
It is common situation when one message is embedded in another ones' buffer of bytes thus hiding the exact type. This method simplifies parsing procedure in such cases