### PR TITLE
fix bug ts not generate type message for not array types

### DIFF
--- a/messgen/ts_generator.py
+++ b/messgen/ts_generator.py
@@ -28,7 +28,7 @@ def format_type(f):
         din_type = to_camelcase(f_type.split('/').pop())
         f_type = din_type + "Message"
 
-    if (f["is_array"] or f["is_dynamic"]):
+    if (f["is_array"]):
         f_type += "[]"
 
     return f_type

--- a/messgen/ts_generator.py
+++ b/messgen/ts_generator.py
@@ -24,11 +24,11 @@ def format_type(f):
     t = ts_types_map.get(f["type"], f["type"])
     f_type = t[0].lower() + t[1:]
 
-    if (f["is_dynamic"] and '/' in f["type"]):
+    if ('/' in f["type"]):
         din_type = to_camelcase(f_type.split('/').pop())
         f_type = din_type + "Message"
 
-    if (f["is_array"]):
+    if (f["is_array"] or f["is_dynamic"]):
         f_type += "[]"
 
     return f_type


### PR DESCRIPTION
if type not array 
![radix-ui – node_parameters yaml 2022-08-29 13-04-05](https://user-images.githubusercontent.com/1769500/187177207-6abde0a8-0903-4c55-bcf0-ab2f4c8769c1.jpg)
we get a problem
![radix-ui – protocol d ts 2022-08-29 13-04-55](https://user-images.githubusercontent.com/1769500/187177345-6cb470c5-b101-40dc-aa07-266eeb5854de.jpg)

the `is_dynamic` field means that we are working with an array of unknown size
