### PR TITLE
Add get_message_name() to cpp generator

### DIFF
--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -371,6 +371,9 @@ class CppGenerator:
         self.generate_data_fields(data_type["fields"])
         self.append("")
 
+        self.generate_get_message_name_method(message_obj)
+        self.append("")
+
         cpp_typename = message_obj["typename"].replace("/", "::")
         self.generate_compare_operator(cpp_typename, data_type)
         self.append("")
@@ -435,6 +438,13 @@ class CppGenerator:
         self.start_block("size_t get_size() const")
         self.extend([
             "return STATIC_SIZE + get_dynamic_size();"
+        ])
+        self.stop_block()
+
+    def generate_get_message_name_method(self, message_obj):
+        self.start_block("static const char* get_message_name()")
+        self.extend([
+            "return \"" + message_obj["name"] + "\";"
         ])
         self.stop_block()
 


### PR DESCRIPTION
Here's an example of what it looks like in generated code:
```cpp
namespace msgs {
namespace protocol {

struct ok_reply {
    static constexpr uint8_t TYPE = 15;
    static constexpr size_t STATIC_SIZE = 4;
    static constexpr uint8_t PROTO = PROTO_ID;
    static constexpr bool HAS_DYNAMICS = false;

    uint32_t reply_id;

    static const char* get_message_name() {
        return "ok_reply";
    }

    bool operator== (const radix::msgs::protocol::ok_reply& other) const {
    ...
```

You can now log every send/receive event in explicit human-readable format:
```cpp
template<class MESSAGE>
void send(const MESSAGE& message, bool flush = true) {
    _logger->debug("send {} of size {} to '{}'", message.get_message_name(), size, get_name());
    // logs as: send ok_reply of size 9 to 'admin'
}
```
