### PR TITLE
meaningful error messages (close #55)

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -135,12 +135,13 @@ def main():
 
         g_type = generators.get(args.lang)
         if g_type is None:
-            raise Exception("Unsupported language " + args.lang)
+            raise MessgenException("Unsupported language \"%s\"" % args.lang)
 
         g = g_type(modules_map, data_types_map, MODULE_SEP, variables)
         g.generate(args.outdir)
+        print("Successfully generated to %s" % args.outdir)
     except MessgenException as e:
-        print(e)
+        print("ERROR: %s" % e)
         exit(-1)
 
 

--- a/messgen/parser.py
+++ b/messgen/parser.py
@@ -70,6 +70,8 @@ def load_modules(basedirs, modules):
                                     "Duplicate ID=%s for messages '%s' and '%s' in module %s"
                                     % (m["id"], m["name"], msg["name"], module_name))
                         module_messages.append(msg)
+            else:
+                raise MessgenException("Path not found: %s" % module_path)
 
         modules_map[module_name] = {
             "proto_id": proto_id,


### PR DESCRIPTION
Here's what the output should look like:
```
$ python3 generate.py -b ./radix-protocol -m radix/modem -l cppp -o out/cpp
ERROR: Unsupported language "cppp"
$ python3 generate.py -b ./radix-protocol -m 2radix/modem -l cpp -o out/cpp
ERROR: Path not found: ./radix-protocol/2radix/modem
$ python3 generate.py -b ./radix-protocol -m radix/modem -l cpp -o out/cpp 
Successfully generated to out/cpp
```