### PR TITLE
fix typing fixed array in md

### DIFF
--- a/messgen/md_generator.py
+++ b/messgen/md_generator.py
@@ -35,7 +35,11 @@ def format_type(f):
         f_type = "[%s](#%s)" % (din_type, to_kebabcase(din_type))
 
     if f["is_array"]:
-        f_type += "[]"
+        if f['num']>1:
+            f_type +=  f"[{f['num']}]"
+        else:
+            f_type += "[]"
+
 
     return f_type
 


### PR DESCRIPTION
## before 


| Field | Type                                 | Comment |
|-------|--------------------------------------|---------|
| f2    | uint64[]                            |         |
| f0    | uint8[]                            |         |
| f1    | [simple_message](#simple_message)[] |         |
| f3    | [simple_message](#simple_message)    |         |

## after

### embedded_message_d1

id:1

| Field | Type                                 | Comment |
|-------|--------------------------------------|---------|
| f2    | uint64[5]                            |         |
| f0    | uint8[10]                            |         |
| f1    | [simple_message](#simple_message)[2] |         |
| f3    | [simple_message](#simple_message)    |         |
