### PR TITLE
CMake integration: Do not depend on non existent file

### DIFF
--- a/integrations/cmake/messgen.cmake
+++ b/integrations/cmake/messgen.cmake
@@ -53,8 +53,10 @@ function(messgen_generate_messages BASE_DIRS PROTOCOLS OUTDIR OUTFILES_VAR OPTIO
                         ${MESSAGES_PATH}/_protocol.yaml
                 )
 
+                get_filename_component(PROTOCOL_BASE ${MESSAGES_OUTDIR} DIRECTORY)
+                get_filename_component(PROTOCOL_NAME ${PROTOCOL} NAME)
                 list(APPEND OUTFILES
-                        ${MESSAGES_OUTDIR}.h
+                        ${PROTOCOL_BASE}/${PROTOCOL_NAME}.h
                 )
             endif ()
         endforeach ()

--- a/integrations/cmake/messgen.cmake
+++ b/integrations/cmake/messgen.cmake
@@ -54,7 +54,7 @@ function(messgen_generate_messages BASE_DIRS PROTOCOLS OUTDIR OUTFILES_VAR OPTIO
                 )
 
                 list(APPEND OUTFILES
-                        ${MESSAGES_OUTDIR}/proto.h
+                        ${MESSAGES_OUTDIR}.h
                 )
             endif ()
         endforeach ()


### PR DESCRIPTION
**Problem:** messgen generation is always triggered, irrespective of the fact that nothing changed in the protocol.

Running:
```
ninja -d explain {target}
```

The result is:
```
ninja explain: output build.ninja older than most recent input
integrations/cmake/messgen.cmake (1722261582277234455 vs 1722261773992042643)
[0/1] Re-running CMake...
...
ninja explain: {path}/{protocol}/proto.h doesn't exist
```

Seems the dependency should be against `{path}/{protocol}.h`