### PR TITLE
Relax requirement check in dispatch

### DIFF
--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -131,7 +131,7 @@ class CppGenerator:
         proto_id = proto["proto_id"]
         if proto_id is not None:
             code.append("static constexpr int PROTO_ID = %s;" % proto_id)
-            code.append()
+            code.append("")
 
         for type_name in proto.get("types"):
             type_def = self._protocols.get_type(proto_name, type_name)

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -130,7 +130,8 @@ class CppGenerator:
 
         proto_id = proto["proto_id"]
         if proto_id is not None:
-            code.append("static constexpr int PROTO_ID = %s;\n" % proto_id)
+            code.append("static constexpr int PROTO_ID = %s;" % proto_id)
+            code.append()
 
         for type_name in proto.get("types"):
             type_def = self._protocols.get_type(proto_name, type_name)

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -130,7 +130,7 @@ class CppGenerator:
 
         proto_id = proto["proto_id"]
         if proto_id is not None:
-            code.append("static constexpr int PROTO_ID = %s;" % proto_id)
+            code.append("static constexpr int PROTO_ID = %s;\n" % proto_id)
 
         for type_name in proto.get("types"):
             type_def = self._protocols.get_type(proto_name, type_name)
@@ -147,7 +147,7 @@ class CppGenerator:
             type_id = type_def.get("id")
             if type_id is not None:
                 code.append(_indent("        case %s::TYPE_ID:" % type_name))
-                code.append(_indent("            if constexpr (requires { handler(%s()); }) {" % type_name))
+                code.append(_indent("            if constexpr (requires(%s msg) { handler(msg); }) {" % type_name))
                 if type_def["is_flat"]:
                     code.append(_indent("                auto &msg = *reinterpret_cast<const %s *>(payload);" % type_name))
                 else:


### PR DESCRIPTION
Relaxes handler requirements in dispatch

With `requires { handler(%s()); }` handler cannot
accept the value via plain reference (non-const).
This does not match the actual code that does
the dispatch, it can therefore be surprising for
users.