### PR TITLE
Add simple message reflection mechanism

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install gtest
-      run: sudo apt-get install libgtest-dev cmake
+      run: sudo apt-get install libgtest-dev cmake ninja-build gcc g++
 
     - name: Build & run tests
       run: mkdir -p build && cmake -Bbuild -S. -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install gtest manually
-      run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+      run: sudo apt-get install libgtest-dev cmake
 
     - name: Run tests
       run: cd tests && make all

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install gtest manually
+    - name: Install gtest
       run: sudo apt-get install libgtest-dev cmake
 
-    - name: Run tests
-      run: cd tests && make all
+    - name: Build & run tests
+      run: mkdir -p build && cmake -Bbuild -S. -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -25,4 +25,4 @@ jobs:
         mkdir -p build
         cmake -Bbuild -S. -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
         cmake --build build
-        ctest --test-dir build/tests/
+        ctest --test-dir build/tests/ --output-on-failure

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -18,4 +18,7 @@ jobs:
       run: sudo apt-get install libgtest-dev cmake ninja-build gcc g++
 
     - name: Build & run tests
-      run: mkdir -p build && cmake -Bbuild -S. -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
+      run: |
+        mkdir -p build
+        cmake -Bbuild -S. -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
+        cmake --build build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -12,10 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - uses: actions/checkout@v3
 
-    - name: Install dependencies
-      run: sudo apt-get install libgtest-dev cmake ninja-build gcc g++
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libgtest-dev cmake ninja-build gcc g++
+          version: 1.0
+
 
     - name: Build & run tests
       run: |

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -22,3 +22,4 @@ jobs:
         mkdir -p build
         cmake -Bbuild -S. -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug
         cmake --build build
+        ctest --test-dir build/tests/

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -2,9 +2,9 @@ name: C++ CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "v1" ]
   pull_request:
-    branches: [ "master"  ]
+    branches: [ "master", "v1" ]
 
 jobs:
   build:
@@ -13,7 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+
     - name: Run tests
       run: cd tests && make all

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -16,9 +16,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libgtest-dev cmake ninja-build gcc g++
-          version: 1.0
+      with:
+        packages: libgtest-dev cmake ninja-build gcc g++
+        version: 1.0
 
 
     - name: Build & run tests

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install gtest
+    - name: Install dependencies
       run: sudo apt-get install libgtest-dev cmake ninja-build gcc g++
 
     - name: Build & run tests

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -20,7 +20,6 @@ jobs:
         packages: libgtest-dev cmake ninja-build gcc g++
         version: 1.0
 
-
     - name: Build & run tests
       run: |
         mkdir -p build

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@
 .run
 
 # Build files
+.cache
 *.pyc
 *.pyd
 cmake-build-*/
+build
+Testing
 
 # Log files
 dump.txt

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -3,6 +3,7 @@ import os
 from .common import SEPARATOR, SIZE_TYPE, write_file_if_diff
 from .protocols import Protocols
 
+
 def _inline_comment(comment):
     if comment:
         return "  ///< %s" % comment

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -453,7 +453,7 @@ class CppGenerator:
 
         code: list[str] = []
         code.append("")
-        code.append(f"[[nodiscard]] inline constexpr auto members_of(::messgen::reflect_t<{type_name}>) {{")
+        code.append(f"[[nodiscard]] inline constexpr auto members_of(::messgen::reflect_t<{type_name}>) noexcept {{")
         code.append("    return std::tuple{")
         for field in fields:
             field_name = field["name"]

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -443,6 +443,8 @@ class CppGenerator:
         type_def = self._protocols.get_type(curr_proto_name, type_name)
         fields = type_def["fields"]
 
+        self._add_include("tuple")
+
         code: list[str] = []
         code.append("")
         code.append(f"[[nodiscard]] inline constexpr auto members_of(::messgen::reflect_t<{type_name}>) {{")
@@ -574,8 +576,6 @@ class CppGenerator:
             el_type_def = self._protocols.get_type(self._ctx["proto_name"], field_type_def["element_type"])
             el_size = el_type_def.get("size")
             el_align = self._get_alignment(el_type_def)
-
-            print("***** ", el_type_def, el_size)
 
             if el_size == 0:
                 pass

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -207,13 +207,19 @@ class CppGenerator:
         return code
 
     def _generate_type_enum(self, type_name, type_def):
-        code = []
+        self._add_include("messgen/messgen.h")
 
+        code = []
         code.extend(self._generate_comment_type(type_def))
         code.append("enum class %s : %s {" % (type_name, self._cpp_type(type_def["base_type"])))
         for item in type_def["values"]:
             code.append("    %s = %s,%s" % (item["name"], item["value"], _inline_comment(item.get("comment"))))
         code.append("};")
+
+        code.append("")
+        code.append(f"[[nodiscard]] inline constexpr std::string_view name_of(::messgen::reflect_t<{type_name}>) noexcept {{")
+        code.append("    return \"%s\";" % type_name)
+        code.append("}")
 
         return code
 

--- a/messgen/go_generator.py
+++ b/messgen/go_generator.py
@@ -172,7 +172,7 @@ def make_const_type(enumName, basetype, fields):
     for field in fields:
         value = "%s" % field["value"]
 
-        matches = re.fullmatch("\s*\(?(\d+)U\s*<<\s*(\d+)U\)?", value)
+        matches = re.fullmatch("\\s*\\(?(\\d+)U\\s*<<\\s*(\\d+)U\\)?", value)
         if matches is not None:
             value = matches.expand("\\1 << \\2")
 

--- a/messgen/protocols.py
+++ b/messgen/protocols.py
@@ -3,6 +3,7 @@ import yaml
 from .common import SEPARATOR
 from .validation import is_valid_name, validate_yaml_item
 
+
 # Protocols map structure:
 # {
 #   proto_name: {
@@ -28,11 +29,11 @@ from .validation import is_valid_name, validate_yaml_item
 #   // - enum
 #   base_type: <base_type>,   // scalar integer type, e.g. uint8, uint32
 #   values: {
-#     <item_0>: {
-#       value: <value_0>,
-#       comment: <comment_0>,   // optional
+#     <item_0> : {
+#       value : <value_0>,
+#       comment : <comment_0>,   // optional
 #     },
-#     <item_1>: {
+#     <item_1> : {
 #       ...
 #     },
 #     ...
@@ -41,15 +42,16 @@ from .validation import is_valid_name, validate_yaml_item
 #   // - struct
 #   fields: [
 #     {
-#       name: <name_0>,
-#       type: <type_0>,
-#       comment: <comment_0>,   // optional
+#       name : <name_0>,
+#       type : <type_0>,
+#       comment : <comment_0>,   // optional
 #     },
 #     {
 #       ...
 #     },
 #     ...
-
+#   ]
+#
 # Field type structure:
 # - scalar:
 #   e.g. "uint8"
@@ -59,6 +61,7 @@ from .validation import is_valid_name, validate_yaml_item
 #   e.g. "uint8[4]"
 # - vector:
 #   e.g. "uint8[]"
+
 
 CONFIG_EXT = ".yaml"
 PROTOCOL_ITEM = "_protocol"

--- a/port/cpp_nostl/messgen/messgen.h
+++ b/port/cpp_nostl/messgen/messgen.h
@@ -30,22 +30,22 @@ struct member {
 
 template <class S, class C, class M>
     requires std::same_as<std::remove_cvref_t<S>, std::remove_cvref_t<C>>
-constexpr decltype(auto) value_of(S &&obj, const member<C, M> &m) {
+[[nodiscard]] constexpr decltype(auto) value_of(S &&obj, const member<C, M> &m) noexcept {
     return std::forward<S>(obj).*m.ptr;
 }
 
 template <class C, class M>
-constexpr auto parent_of(const member<C, M> &) {
+[[nodiscard]] constexpr auto parent_of(const member<C, M> &) noexcept {
     return reflect_type<typename member<C, M>::class_type>;
 }
 
 template <class C, class M>
-constexpr auto type_of(const member<C, M> &) {
+[[nodiscard]] constexpr auto type_of(const member<C, M> &) noexcept {
     return reflect_type<typename member<C, M>::member_type>;
 }
 
 template <class C, class M>
-constexpr const char *name_of(const member<C, M> &m) {
+[[nodiscard]] constexpr std::string_view name_of(const member<C, M> &m) noexcept {
     return m.name;
 }
 
@@ -53,60 +53,66 @@ template <class T>
     requires requires(T &&t) {
         { t.NAME };
     }
-constexpr const char *name_of(reflect_t<T>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<T>) noexcept {
     return T::NAME;
 }
 
-constexpr const char *name_of(reflect_t<bool>) {
+template <class T>
+    requires std::is_enum_v<T>
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<T> r) noexcept {
+    return name_of(r);
+}
+
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<bool>) noexcept {
     return "bool";
 }
 
-constexpr const char *name_of(reflect_t<uint8_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint8_t>) noexcept {
     return "uint8_t";
 }
 
-constexpr const char *name_of(reflect_t<int8_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int8_t>) noexcept {
     return "int8_t";
 }
 
-constexpr const char *name_of(reflect_t<uint16_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint16_t>) noexcept {
     return "uint16_t";
 }
 
-constexpr const char *name_of(reflect_t<int16_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int16_t>) noexcept {
     return "int16_t";
 }
 
-constexpr const char *name_of(reflect_t<uint32_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint32_t>) noexcept {
     return "uint32_t";
 }
 
-constexpr const char *name_of(reflect_t<int32_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int32_t>) noexcept {
     return "int32_t";
 }
 
-constexpr const char *name_of(reflect_t<uint64_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint64_t>) noexcept {
     return "uint64_t";
 }
 
-constexpr const char *name_of(reflect_t<int64_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int64_t>) noexcept {
     return "int64_t";
 }
 
-constexpr const char *name_of(reflect_t<float>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<float>) noexcept {
     return "float";
 }
 
-constexpr const char *name_of(reflect_t<double>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<double>) noexcept {
     return "double";
 }
 
-constexpr const char *name_of(reflect_t<std::string>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<std::string>) noexcept {
     return "string";
 }
 
 template <class T>
-const char *name_of(reflect_t<std::vector<T>>) {
+[[nodiscard]] std::string_view name_of(reflect_t<std::vector<T>>) {
     static auto name = "vector<" + std::string(name_of(reflect_type<T>)) + ">";
     return name.c_str();
 }

--- a/port/cpp_nostl/messgen/messgen.h
+++ b/port/cpp_nostl/messgen/messgen.h
@@ -12,6 +12,9 @@ using reflect_t = T *; // we could use a hard type instead, but that would incur
                        // a penalty on compile time
 
 template <class T>
+using splice_t = std::remove_pointer_t<T>;
+
+template <class T>
 constexpr reflect_t<T> reflect_type = {};
 
 template <class T>

--- a/port/cpp_nostl/messgen/messgen.h
+++ b/port/cpp_nostl/messgen/messgen.h
@@ -1,14 +1,134 @@
 #pragma once
 
-#include "Allocator.h"
-
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace messgen {
 
+template <class T>
+using reflect_t = T *; // we could use a hard type instead, but that would incur
+                       // a penalty on compile time
+
+template <class T>
+constexpr reflect_t<T> reflect_type = {};
+
+template <class T>
+constexpr reflect_t<std::remove_cvref_t<T>> reflect_object(T &&t) {
+    return &t;
+}
+
+template <class C, class M>
+struct member {
+    using class_type = C;
+    using member_type = std::remove_cvref_t<M>;
+
+    const char *name;
+    M C::*ptr;
+};
+
+template <class S, class C, class M>
+    requires std::same_as<std::remove_cvref_t<S>, std::remove_cvref_t<C>>
+constexpr decltype(auto) value_of(S &&obj, const member<C, M> &m) {
+    return std::forward<S>(obj).*m.ptr;
+}
+
+template <class C, class M>
+constexpr auto parent_of(const member<C, M> &) {
+    return reflect_type<typename member<C, M>::class_type>;
+}
+
+template <class C, class M>
+constexpr auto type_of(const member<C, M> &) {
+    return reflect_type<typename member<C, M>::member_type>;
+}
+
+template <class C, class M>
+constexpr const char *name_of(const member<C, M> &m) {
+    return m.name;
+}
+
+template <class T>
+    requires requires(T &&t) {
+        { t.NAME };
+    }
+constexpr const char *name_of(reflect_t<T>) {
+    return T::NAME;
+}
+
+constexpr const char *name_of(reflect_t<bool>) {
+    return "bool";
+}
+
+constexpr const char *name_of(reflect_t<uint8_t>) {
+    return "uint8_t";
+}
+
+constexpr const char *name_of(reflect_t<int8_t>) {
+    return "int8_t";
+}
+
+constexpr const char *name_of(reflect_t<uint16_t>) {
+    return "uint16_t";
+}
+
+constexpr const char *name_of(reflect_t<int16_t>) {
+    return "int16_t";
+}
+
+constexpr const char *name_of(reflect_t<uint32_t>) {
+    return "uint32_t";
+}
+
+constexpr const char *name_of(reflect_t<int32_t>) {
+    return "int32_t";
+}
+
+constexpr const char *name_of(reflect_t<uint64_t>) {
+    return "uint64_t";
+}
+
+constexpr const char *name_of(reflect_t<int64_t>) {
+    return "int64_t";
+}
+
+constexpr const char *name_of(reflect_t<float>) {
+    return "float";
+}
+
+constexpr const char *name_of(reflect_t<double>) {
+    return "double";
+}
+
+constexpr const char *name_of(reflect_t<std::string>) {
+    return "string";
+}
+
+template <class T, auto N>
+constexpr const char *name_of(reflect_t<std::array<T, N>>) {
+    static auto name = "array<" + std::string(name_of(reflect_type<T>)) + ", " + std::to_string(N) + ">";
+    return name.c_str();
+}
+
+template <class T>
+constexpr const char *name_of(reflect_t<std::vector<T>>) {
+    static auto name = "vector<" + std::string(name_of(reflect_type<T>)) + ">";
+    return name.c_str();
+}
+
+template <class K, class V>
+constexpr const char *name_of(reflect_t<std::map<K, V>>) {
+    static auto name = "map<" + std::string(name_of(reflect_type<K>)) + "," + std::string(name_of(reflect_type<V>)) + ">";
+    return name.c_str();
+}
+
 using size_type = uint32_t;
 
-template<class T>
+template <class T>
 struct vector {
     T *_ptr = nullptr;
     size_t _size = 0;
@@ -20,20 +140,31 @@ struct vector {
         _size = other._size;
     }
 
-    vector(T *ptr, size_t size) : _ptr(ptr), _size(size) {}
+    vector(T *ptr, size_t size)
+        : _ptr(ptr),
+          _size(size) {
+    }
 
-    vector(const T *ptr, size_t size) : _ptr(const_cast<T *>(ptr)), _size(size) {}
+    vector(const T *ptr, size_t size)
+        : _ptr(const_cast<T *>(ptr)),
+          _size(size) {
+    }
 
-    vector(std::vector<T> &v) : _ptr(v.begin().base()), _size(v.size()) {}
+    vector(std::vector<T> &v)
+        : _ptr(v.begin().base()),
+          _size(v.size()) {
+    }
 
-    vector(const std::vector<T> &v) : _ptr(const_cast<T *>(v.begin().base())), _size(v.size()) {}
+    vector(const std::vector<T> &v)
+        : _ptr(const_cast<T *>(v.begin().base())),
+          _size(v.size()) {
+    }
 
     vector<T> &operator=(const vector<T> &other) {
         _ptr = other._ptr;
         _size = other._size;
         return *this;
     }
-
 
     size_t size() const {
         return _size;
@@ -78,4 +209,4 @@ struct vector {
     }
 };
 
-}
+} // namespace messgen

--- a/port/cpp_nostl/messgen/messgen.h
+++ b/port/cpp_nostl/messgen/messgen.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <array>
-#include <concepts>
-#include <cstdint>
-#include <map>
-#include <string>
-#include <utility>
+#include "Allocator.h"
+
 #include <vector>
+#include <string>
 
 namespace messgen {
 
@@ -108,21 +105,9 @@ constexpr const char *name_of(reflect_t<std::string>) {
     return "string";
 }
 
-template <class T, auto N>
-constexpr const char *name_of(reflect_t<std::array<T, N>>) {
-    static auto name = "array<" + std::string(name_of(reflect_type<T>)) + ", " + std::to_string(N) + ">";
-    return name.c_str();
-}
-
 template <class T>
-constexpr const char *name_of(reflect_t<std::vector<T>>) {
+const char *name_of(reflect_t<std::vector<T>>) {
     static auto name = "vector<" + std::string(name_of(reflect_type<T>)) + ">";
-    return name.c_str();
-}
-
-template <class K, class V>
-constexpr const char *name_of(reflect_t<std::map<K, V>>) {
-    static auto name = "map<" + std::string(name_of(reflect_type<K>)) + "," + std::string(name_of(reflect_type<V>)) + ">";
     return name.c_str();
 }
 

--- a/port/cpp_nostl/messgen/messgen.h
+++ b/port/cpp_nostl/messgen/messgen.h
@@ -192,6 +192,14 @@ struct vector {
     const T &operator[](size_t idx) const {
         return _ptr[idx];
     }
+
+    T *data() {
+        return _ptr;
+    }
+
+    const T *data() const {
+        return _ptr;
+    }
 };
 
 } // namespace messgen

--- a/port/cpp_stl/messgen/messgen.h
+++ b/port/cpp_stl/messgen/messgen.h
@@ -16,6 +16,9 @@ using reflect_t = T *; // we could use a hard type instead, but that would incur
                        // a penalty on compile time
 
 template <class T>
+using splice_t = std::remove_pointer_t<T>;
+
+template <class T>
 constexpr reflect_t<T> reflect_type = {};
 
 template <class T>

--- a/port/cpp_stl/messgen/messgen.h
+++ b/port/cpp_stl/messgen/messgen.h
@@ -1,9 +1,131 @@
 #pragma once
 
+#include <array>
+#include <concepts>
 #include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace messgen {
 
+template <class T>
+using reflect_t = T *; // we could use a hard type instead, but that would incur
+                       // a penalty on compile time
+
+template <class T>
+constexpr reflect_t<T> reflect_type = {};
+
+template <class T>
+constexpr reflect_t<std::remove_cvref_t<T>> reflect_object(T &&t) {
+    return &t;
+}
+
+template <class C, class M>
+struct member {
+    using class_type = C;
+    using member_type = std::remove_cvref_t<M>;
+
+    const char *name;
+    M C::*ptr;
+};
+
+template <class S, class C, class M>
+    requires std::same_as<std::remove_cvref_t<S>, std::remove_cvref_t<C>>
+constexpr decltype(auto) value_of(S &&obj, const member<C, M> &m) {
+    return std::forward<S>(obj).*m.ptr;
+}
+
+template <class C, class M>
+constexpr auto parent_of(const member<C, M> &) {
+    return reflect_type<typename member<C, M>::class_type>;
+}
+
+template <class C, class M>
+constexpr auto type_of(const member<C, M> &) {
+    return reflect_type<typename member<C, M>::member_type>;
+}
+
+template <class C, class M>
+constexpr const char *name_of(const member<C, M> &m) {
+    return m.name;
+}
+
+template <class T>
+    requires requires(T &&t) {
+        { t.NAME };
+    }
+constexpr const char *name_of(reflect_t<T>) {
+    return T::NAME;
+}
+
+constexpr const char *name_of(reflect_t<bool>) {
+    return "bool";
+}
+
+constexpr const char *name_of(reflect_t<uint8_t>) {
+    return "uint8_t";
+}
+
+constexpr const char *name_of(reflect_t<int8_t>) {
+    return "int8_t";
+}
+
+constexpr const char *name_of(reflect_t<uint16_t>) {
+    return "uint16_t";
+}
+
+constexpr const char *name_of(reflect_t<int16_t>) {
+    return "int16_t";
+}
+
+constexpr const char *name_of(reflect_t<uint32_t>) {
+    return "uint32_t";
+}
+
+constexpr const char *name_of(reflect_t<int32_t>) {
+    return "int32_t";
+}
+
+constexpr const char *name_of(reflect_t<uint64_t>) {
+    return "uint64_t";
+}
+
+constexpr const char *name_of(reflect_t<int64_t>) {
+    return "int64_t";
+}
+
+constexpr const char *name_of(reflect_t<float>) {
+    return "float";
+}
+
+constexpr const char *name_of(reflect_t<double>) {
+    return "double";
+}
+
+constexpr const char *name_of(reflect_t<std::string>) {
+    return "string";
+}
+
+template <class T, auto N>
+constexpr const char *name_of(reflect_t<std::array<T, N>>) {
+    static auto name = "array<" + std::string(name_of(reflect_type<T>)) + ", " + std::to_string(N) + ">";
+    return name.c_str();
+}
+
+template <class T>
+constexpr const char *name_of(reflect_t<std::vector<T>>) {
+    static auto name = "vector<" + std::string(name_of(reflect_type<T>)) + ">";
+    return name.c_str();
+}
+
+template <class K, class V>
+constexpr const char *name_of(reflect_t<std::map<K, V>>) {
+    static auto name = "map<" + std::string(name_of(reflect_type<K>)) + "," + std::string(name_of(reflect_type<V>)) + ">";
+    return name.c_str();
+}
+
 using size_type = uint32_t;
 
-}
+} // namespace messgen

--- a/port/cpp_stl/messgen/messgen.h
+++ b/port/cpp_stl/messgen/messgen.h
@@ -109,19 +109,19 @@ constexpr const char *name_of(reflect_t<std::string>) {
 }
 
 template <class T, auto N>
-constexpr const char *name_of(reflect_t<std::array<T, N>>) {
+const char *name_of(reflect_t<std::array<T, N>>) {
     static auto name = "array<" + std::string(name_of(reflect_type<T>)) + ", " + std::to_string(N) + ">";
     return name.c_str();
 }
 
 template <class T>
-constexpr const char *name_of(reflect_t<std::vector<T>>) {
+const char *name_of(reflect_t<std::vector<T>>) {
     static auto name = "vector<" + std::string(name_of(reflect_type<T>)) + ">";
     return name.c_str();
 }
 
 template <class K, class V>
-constexpr const char *name_of(reflect_t<std::map<K, V>>) {
+const char *name_of(reflect_t<std::map<K, V>>) {
     static auto name = "map<" + std::string(name_of(reflect_type<K>)) + "," + std::string(name_of(reflect_type<V>)) + ">";
     return name.c_str();
 }

--- a/port/cpp_stl/messgen/messgen.h
+++ b/port/cpp_stl/messgen/messgen.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <string_view>
 
 namespace messgen {
 
@@ -27,28 +28,28 @@ struct member {
     using class_type = C;
     using member_type = std::remove_cvref_t<M>;
 
-    const char *name;
+    std::string_view name;
     M C::*ptr;
 };
 
 template <class S, class C, class M>
     requires std::same_as<std::remove_cvref_t<S>, std::remove_cvref_t<C>>
-constexpr decltype(auto) value_of(S &&obj, const member<C, M> &m) {
+[[nodiscard]] constexpr decltype(auto) value_of(S &&obj, const member<C, M> &m) noexcept {
     return std::forward<S>(obj).*m.ptr;
 }
 
 template <class C, class M>
-constexpr auto parent_of(const member<C, M> &) {
+[[nodiscard]] constexpr auto parent_of(const member<C, M> &) noexcept {
     return reflect_type<typename member<C, M>::class_type>;
 }
 
 template <class C, class M>
-constexpr auto type_of(const member<C, M> &) {
+[[nodiscard]] constexpr auto type_of(const member<C, M> &) noexcept {
     return reflect_type<typename member<C, M>::member_type>;
 }
 
 template <class C, class M>
-constexpr const char *name_of(const member<C, M> &m) {
+[[nodiscard]] constexpr std::string_view name_of(const member<C, M> &m) noexcept {
     return m.name;
 }
 
@@ -56,73 +57,85 @@ template <class T>
     requires requires(T &&t) {
         { t.NAME };
     }
-constexpr const char *name_of(reflect_t<T>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<T>) noexcept {
     return T::NAME;
 }
 
-constexpr const char *name_of(reflect_t<bool>) {
+template <class T>
+    requires std::is_enum_v<T>
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<T> r) noexcept {
+    return name_of(r);
+}
+
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<bool>) noexcept {
     return "bool";
 }
 
-constexpr const char *name_of(reflect_t<uint8_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint8_t>) noexcept {
     return "uint8_t";
 }
 
-constexpr const char *name_of(reflect_t<int8_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int8_t>) noexcept {
     return "int8_t";
 }
 
-constexpr const char *name_of(reflect_t<uint16_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint16_t>) noexcept {
     return "uint16_t";
 }
 
-constexpr const char *name_of(reflect_t<int16_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int16_t>) noexcept {
     return "int16_t";
 }
 
-constexpr const char *name_of(reflect_t<uint32_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint32_t>) noexcept {
     return "uint32_t";
 }
 
-constexpr const char *name_of(reflect_t<int32_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int32_t>) noexcept {
     return "int32_t";
 }
 
-constexpr const char *name_of(reflect_t<uint64_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<uint64_t>) noexcept {
     return "uint64_t";
 }
 
-constexpr const char *name_of(reflect_t<int64_t>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<int64_t>) noexcept {
     return "int64_t";
 }
 
-constexpr const char *name_of(reflect_t<float>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<float>) noexcept {
     return "float";
 }
 
-constexpr const char *name_of(reflect_t<double>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<double>) noexcept {
     return "double";
 }
 
-constexpr const char *name_of(reflect_t<std::string>) {
+[[nodiscard]] constexpr std::string_view name_of(reflect_t<std::string>) noexcept {
     return "string";
 }
 
+template <class T>
+[[nodiscard]] std::string_view name_of(reflect_t<std::vector<T>>);
+
+template <class K, class V>
+[[nodiscard]] std::string_view name_of(reflect_t<std::map<K, V>>);
+
 template <class T, auto N>
-const char *name_of(reflect_t<std::array<T, N>>) {
+[[nodiscard]] std::string_view name_of(reflect_t<std::array<T, N>>) {
     static auto name = "array<" + std::string(name_of(reflect_type<T>)) + ", " + std::to_string(N) + ">";
     return name.c_str();
 }
 
 template <class T>
-const char *name_of(reflect_t<std::vector<T>>) {
+[[nodiscard]] std::string_view name_of(reflect_t<std::vector<T>>) {
     static auto name = "vector<" + std::string(name_of(reflect_type<T>)) + ">";
     return name.c_str();
 }
 
 template <class K, class V>
-const char *name_of(reflect_t<std::map<K, V>>) {
-    static auto name = "map<" + std::string(name_of(reflect_type<K>)) + "," + std::string(name_of(reflect_type<V>)) + ">";
+[[nodiscard]] std::string_view name_of(reflect_t<std::map<K, V>>) {
+    static auto name = "map<" + std::string(name_of(reflect_type<K>)) + ", " + std::string(name_of(reflect_type<V>)) + ">";
     return name.c_str();
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(messgen)
 
+include(GoogleTest)
+
 set(MESSGEN_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}/messages")
 
 add_executable(test_cpp "cpp_stl/main.cpp")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,29 +1,28 @@
-cmake_minimum_required(VERSION 3.5)
-
-project(messgen)
-
 include(GoogleTest)
+find_package(GTest REQUIRED)
+
+enable_testing()
 
 set(MESSGEN_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}/messages")
 
-add_executable(test_cpp "cpp_stl/main.cpp")
+add_executable(test_cpp "cpp/CppTest.cpp")
 messgen_add_library(msgs_test_proto "${MESSGEN_BASE_DIR}" "messgen/test_proto;another_proto" "stl" "cpp_standard=20")
-target_link_libraries(test_cpp gtest msgs_test_proto)
+target_link_libraries(test_cpp gtest msgs_test_proto GTest::gtest_main)
 gtest_discover_tests(test_cpp)
 
-add_executable(test_cpp_nostl "cpp_nostl/main.cpp")
+add_executable(test_cpp_nostl "cpp/CppNostlTest.cpp")
 messgen_add_library(msgs_test_proto_nostl "${MESSGEN_BASE_DIR}" "messgen/test_proto" "nostl" "cpp_standard=20")
-target_link_libraries(test_cpp_nostl gtest msgs_test_proto_nostl)
+target_link_libraries(test_cpp_nostl gtest msgs_test_proto_nostl GTest::gtest_main)
 gtest_discover_tests(test_cpp_nostl)
 
 # Make executables form the same source files but without "cpp_standard=20" option (messgen may work differently)
 
-add_executable(test_cpp_17 "cpp_stl/main.cpp")
+add_executable(test_cpp_17 "cpp/CppTest.cpp")
 messgen_add_library(msgs_test_proto_cpp17 "${MESSGEN_BASE_DIR}" "messgen/test_proto;another_proto" "stl")
-target_link_libraries(test_cpp_17 gtest msgs_test_proto_cpp17)
+target_link_libraries(test_cpp_17 gtest msgs_test_proto_cpp17 GTest::gtest_main)
 gtest_discover_tests(test_cpp_17)
 
-add_executable(test_cpp_17_nostl "cpp_nostl/main.cpp")
+add_executable(test_cpp_17_nostl "cpp/CppNostlTest.cpp")
 messgen_add_library(msgs_test_proto_nostl_cpp17 "${MESSGEN_BASE_DIR}" "messgen/test_proto" "nostl")
-target_link_libraries(test_cpp_17_nostl gtest msgs_test_proto_nostl_cpp17)
+target_link_libraries(test_cpp_17_nostl gtest msgs_test_proto_nostl_cpp17 GTest::gtest_main)
 gtest_discover_tests(test_cpp_17_nostl)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,17 +7,21 @@ set(MESSGEN_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}/messages")
 add_executable(test_cpp "cpp_stl/main.cpp")
 messgen_add_library(msgs_test_proto "${MESSGEN_BASE_DIR}" "messgen/test_proto;another_proto" "stl" "cpp_standard=20")
 target_link_libraries(test_cpp gtest msgs_test_proto)
+gtest_discover_tests(test_cpp)
 
 add_executable(test_cpp_nostl "cpp_nostl/main.cpp")
 messgen_add_library(msgs_test_proto_nostl "${MESSGEN_BASE_DIR}" "messgen/test_proto" "nostl" "cpp_standard=20")
 target_link_libraries(test_cpp_nostl gtest msgs_test_proto_nostl)
+gtest_discover_tests(test_cpp_nostl)
 
 # Make executables form the same source files but without "cpp_standard=20" option (messgen may work differently)
 
 add_executable(test_cpp_17 "cpp_stl/main.cpp")
 messgen_add_library(msgs_test_proto_cpp17 "${MESSGEN_BASE_DIR}" "messgen/test_proto;another_proto" "stl")
 target_link_libraries(test_cpp_17 gtest msgs_test_proto_cpp17)
+gtest_discover_tests(test_cpp_17)
 
 add_executable(test_cpp_17_nostl "cpp_nostl/main.cpp")
 messgen_add_library(msgs_test_proto_nostl_cpp17 "${MESSGEN_BASE_DIR}" "messgen/test_proto" "nostl")
 target_link_libraries(test_cpp_17_nostl gtest msgs_test_proto_nostl_cpp17)
+gtest_discover_tests(test_cpp_17_nostl)

--- a/tests/cpp/CppNostlTest.cpp
+++ b/tests/cpp/CppNostlTest.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <messgen/messgen.h>
 #include <messgen/test_proto/complex_struct_nostl.h>
 #include <messgen/test_proto/struct_with_enum.h>
@@ -13,7 +11,7 @@ protected:
     std::vector<uint8_t> _buf;
     messgen::StaticAllocator<1024 * 1024> _alloc;
 
-    template<class T>
+    template <class T>
     void test_serialization(const T &msg) {
         size_t sz_check = msg.serialized_size();
 

--- a/tests/cpp/CppTest.cpp
+++ b/tests/cpp/CppTest.cpp
@@ -85,6 +85,7 @@ TEST_F(CppTest, VarSizeStruct) {
 
 TEST_F(CppTest, ComplexStruct) {
     messgen::test_proto::complex_struct msg{};
+
     msg.f0 = 255;
     msg.f2_vec.push_back(45.787);
     msg.e_vec.push_back(messgen::test_proto::simple_enum::another_value);

--- a/tests/cpp/CppTest.cpp
+++ b/tests/cpp/CppTest.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <messgen/messgen.h>
 #include <messgen/test_proto/complex_struct.h>
 #include <messgen/test_proto/struct_with_enum.h>
@@ -14,7 +12,7 @@ class CppTest : public ::testing::Test {
 protected:
     std::vector<uint8_t> _buf;
 
-    template<class T>
+    template <class T>
     void test_serialization(const T &msg) {
         size_t sz_check = msg.serialized_size();
 
@@ -29,7 +27,7 @@ protected:
         EXPECT_EQ(msg, msg1);
     }
 
-    template<class T>
+    template <class T>
     void test_zerocopy(const T &msg) {
         size_t sz_check = msg.serialized_size();
 

--- a/tests/cpp_nostl/main.cpp
+++ b/tests/cpp_nostl/main.cpp
@@ -1,9 +1,0 @@
-#include "CppNostlTest.h"
-
-#include <gtest/gtest.h>
-
-
-int main(int argc, char **argv) {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/tests/cpp_stl/main.cpp
+++ b/tests/cpp_stl/main.cpp
@@ -1,9 +1,0 @@
-#include "CppTest.h"
-
-#include <gtest/gtest.h>
-
-
-int main(int argc, char **argv) {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
- Add generic helpers for reflecting messages
- Implement members_of reflection for message members
- Fixed serialization of zero length arrays and vectors
- Make github workflows with messgen v1
- Introduce caching for apt-get install workflow step

The reflection is needed to support the implementation
of generic message printers and protocol serialization
de-serialization (e.g. json).

Implemented unit tests