### PR TITLE
Avoid generating parameter names for empty structs

### DIFF
--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -328,9 +328,11 @@ class CppGenerator:
         code_ser.append("return _size;")
 
         code_ser = ["",
-                    "size_t serialize([[maybe_unused]] uint8_t *_buf) const {",
+                    "size_t serialize(uint8_t *",
+                    "_buf" if not is_empty else "",
+                    ") const {",
                     ] + _indent(code_ser) + [
-                       "}"]
+                    "}"]
         code.extend(_indent(code_ser))
 
         # Deserialize function
@@ -361,9 +363,12 @@ class CppGenerator:
         if self._get_mode() == "nostl":
             alloc = ", messgen::Allocator &_alloc"
         code_deser = ["",
-                      "size_t deserialize([[maybe_unused]] const uint8_t *_buf%s) {" % alloc,
+                      "size_t deserialize(const uint8_t *",
+                      "_buf" if not is_empty else "",
+                      alloc,
+                      ") {",
                       ] + _indent(code_deser) + [
-                         "}"]
+                "}"]
         code.extend(_indent(code_deser))
 
         # Size function

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -361,7 +361,7 @@ class CppGenerator:
         if self._get_mode() == "nostl":
             alloc = ", messgen::Allocator &_alloc"
         code_deser = ["",
-                      "size_t deserialize(const uint8_t *" + ("_buf" if not is_empty else "") + alloc,") {",
+                      "size_t deserialize(const uint8_t *" + ("_buf" if not is_empty else "") + alloc + ") {",
                       ] + _indent(code_deser) + [
                       "}"]
         code.extend(_indent(code_deser))

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -328,9 +328,7 @@ class CppGenerator:
         code_ser.append("return _size;")
 
         code_ser = ["",
-                    "size_t serialize(uint8_t *",
-                    "_buf" if not is_empty else "",
-                    ") const {",
+                    "size_t serialize(uint8_t *", "_buf" if not is_empty else "", ") const {",
                     ] + _indent(code_ser) + [
                     "}"]
         code.extend(_indent(code_ser))
@@ -363,12 +361,9 @@ class CppGenerator:
         if self._get_mode() == "nostl":
             alloc = ", messgen::Allocator &_alloc"
         code_deser = ["",
-                      "size_t deserialize(const uint8_t *",
-                      "_buf" if not is_empty else "",
-                      alloc,
-                      ") {",
+                      "size_t deserialize(const uint8_t *", "_buf" if not is_empty else "", alloc,") {",
                       ] + _indent(code_deser) + [
-                "}"]
+                      "}"]
         code.extend(_indent(code_deser))
 
         # Size function

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -328,7 +328,7 @@ class CppGenerator:
         code_ser.append("return _size;")
 
         code_ser = ["",
-                    "size_t serialize(uint8_t *", "_buf" if not is_empty else "", ") const {",
+                    "size_t serialize(uint8_t *" + ("_buf" if not is_empty else "") + ") const {",
                     ] + _indent(code_ser) + [
                     "}"]
         code.extend(_indent(code_ser))
@@ -361,7 +361,7 @@ class CppGenerator:
         if self._get_mode() == "nostl":
             alloc = ", messgen::Allocator &_alloc"
         code_deser = ["",
-                      "size_t deserialize(const uint8_t *", "_buf" if not is_empty else "", alloc,") {",
+                      "size_t deserialize(const uint8_t *" + ("_buf" if not is_empty else "") + alloc,") {",
                       ] + _indent(code_deser) + [
                       "}"]
         code.extend(_indent(code_deser))

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -328,7 +328,7 @@ class CppGenerator:
         code_ser.append("return _size;")
 
         code_ser = ["",
-                    "size_t serialize(uint8_t *_buf) const {",
+                    "size_t serialize([[maybe_unused]] uint8_t *_buf) const {",
                     ] + _indent(code_ser) + [
                        "}"]
         code.extend(_indent(code_ser))
@@ -361,7 +361,7 @@ class CppGenerator:
         if self._get_mode() == "nostl":
             alloc = ", messgen::Allocator &_alloc"
         code_deser = ["",
-                      "size_t deserialize(const uint8_t *_buf%s) {" % alloc,
+                      "size_t deserialize([[maybe_unused]] const uint8_t *_buf%s) {" % alloc,
                       ] + _indent(code_deser) + [
                          "}"]
         code.extend(_indent(code_deser))
@@ -386,7 +386,7 @@ class CppGenerator:
         code_ss.append("return _size;")
 
         code_ss = ["",
-                   "size_t serialized_size() const {",
+                   "[[nodiscard]] size_t serialized_size() const {",
                    _indent("// %s" % ", ".join(fixed_fields)),
                    _indent("size_t _size = %d;" % fixed_size),
                    "",


### PR DESCRIPTION
- Add `[[nodiscard]]` to `serialized_size()`
- Avoid generating param name in empty `serialize` & `deserialize`

The `[[nodiscard]]` addition is a hopefully no-brainer. Removing
param name in empty `serialize` & `deserialize` is necessary
to prevent compiler warnings of unused variable