### PR TITLE
Add basic concepts to messgen.h

### DIFF
--- a/port/cpp_nostl/messgen/messgen.h
+++ b/port/cpp_nostl/messgen/messgen.h
@@ -211,4 +211,22 @@ struct vector {
     }
 };
 
+template <class Msg>
+concept serializable = requires(Msg msg, uint8_t *buf, Allocator &allocator) {
+    { msg.serialized_size() } -> std::same_as<size_t>;
+    { msg.serialize(buf) } -> std::same_as<size_t>;
+    { msg.deserialize(buf, allocator) } -> std::same_as<size_t>;
+};
+
+template <class Msg>
+concept message = serializable<Msg> && requires {
+    { Msg::PROTO_ID } -> std::convertible_to<int>;
+    { Msg::TYPE_ID } -> std::convertible_to<int>;
+    { Msg::NAME } -> std::convertible_to<const char *>;
+    { Msg::IS_FLAT } -> std::convertible_to<bool>;
+};
+
+template <class Msg>
+concept flat_message = message<Msg> && Msg::IS_FLAT;
+
 } // namespace messgen

--- a/port/cpp_stl/messgen/messgen.h
+++ b/port/cpp_stl/messgen/messgen.h
@@ -144,4 +144,22 @@ template <class K, class V>
 
 using size_type = uint32_t;
 
+template <class Msg>
+concept serializable = requires(Msg msg, uint8_t *buf) {
+    { msg.serialized_size() } -> std::same_as<size_t>;
+    { msg.serialize(buf) } -> std::same_as<size_t>;
+    { msg.deserialize(buf) } -> std::same_as<size_t>;
+};
+
+template <class Msg>
+concept message = serializable<Msg> && requires {
+    { Msg::PROTO_ID } -> std::convertible_to<int>;
+    { Msg::TYPE_ID } -> std::convertible_to<int>;
+    { Msg::NAME } -> std::convertible_to<const char *>;
+    { Msg::IS_FLAT } -> std::convertible_to<bool>;
+};
+
+template <class Msg>
+concept flat_message = message<Msg> && Msg::IS_FLAT;
+
 } // namespace messgen

--- a/tests/cpp/CppNostlTest.cpp
+++ b/tests/cpp/CppNostlTest.cpp
@@ -3,6 +3,7 @@
 #include <messgen/test_proto/struct_with_enum.h>
 #include <messgen/test_proto/var_size_struct.h>
 #include <messgen/test_proto/empty_struct.h>
+#include <messgen/test_proto/flat_struct.h>
 
 #include <gtest/gtest.h>
 
@@ -90,4 +91,22 @@ TEST_F(CppNostlTest, EmptyStruct) {
     ASSERT_EQ(e.FLAT_SIZE, 0);
     ASSERT_EQ(e.serialized_size(), 0);
     test_serialization(e);
+}
+
+TEST_F(CppNostlTest, MessageConcept) {
+    using namespace messgen;
+
+    struct not_a_message {};
+
+    EXPECT_TRUE(message<test_proto::simple_struct>);
+    EXPECT_FALSE(message<not_a_message>);
+    EXPECT_FALSE(message<int>);
+}
+
+TEST_F(CppNostlTest, FlatMessageConcept) {
+    using namespace messgen;
+
+    EXPECT_TRUE(flat_message<test_proto::flat_struct>);
+    EXPECT_FALSE(flat_message<test_proto::var_size_struct>);
+    EXPECT_FALSE(flat_message<int>);
 }

--- a/tests/cpp/CppTest.cpp
+++ b/tests/cpp/CppTest.cpp
@@ -249,7 +249,7 @@ TEST_F(CppTest, EnumReflection) {
     EXPECT_STREQ(enum_name.data(), "simple_enum");
 }
 
-TEST_F(CppTest, DispatchMessage1) {
+TEST_F(CppTest, DispatchMessage) {
     using namespace messgen;
 
     auto expected = test_proto::simple_struct{
@@ -262,7 +262,7 @@ TEST_F(CppTest, DispatchMessage1) {
     auto invoked = false;
     auto handler = [&](auto &&actual) {
         using ActualType = std::decay_t<decltype(actual)>;
-        
+
         if constexpr (std::is_same_v<ActualType, test_proto::simple_struct>) {
             EXPECT_EQ(expected.f0, actual.f0);
             EXPECT_EQ(expected.f1, actual.f1);
@@ -274,4 +274,22 @@ TEST_F(CppTest, DispatchMessage1) {
     test_proto::dispatch_message(test_proto::simple_struct::TYPE_ID, _buf.data(), handler);
 
     EXPECT_TRUE(invoked);
+}
+
+TEST_F(CppTest, MessageConcept) {
+    using namespace messgen;
+
+    struct not_a_message {};
+
+    EXPECT_TRUE(message<test_proto::simple_struct>);
+    EXPECT_FALSE(message<not_a_message>);
+    EXPECT_FALSE(message<int>);
+}
+
+TEST_F(CppTest, FlatMessageConcept) {
+    using namespace messgen;
+
+    EXPECT_TRUE(flat_message<test_proto::flat_struct>);
+    EXPECT_FALSE(flat_message<test_proto::complex_struct>);
+    EXPECT_FALSE(flat_message<int>);
 }


### PR DESCRIPTION
- messgen::serializable
- messgen::message
- messgen::flat_message

These concepts are needed to increase robustness 
and ergonomics of the C++ code bases using messgen.