### PR TITLE
Add schema (type) hash generation

### DIFF
--- a/messgen-generate.py
+++ b/messgen-generate.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+from messgen.validation import validate_protocol
 from messgen import generator, yaml_parser
 from pathlib import Path
 
@@ -26,10 +27,13 @@ def generate(args: argparse.Namespace):
 
     if (gen := generator.get_generator(args.lang, opts)) is not None:
         if parsed_protocols and parsed_types:
-            gen.generate(Path(args.outdir), parsed_types, parsed_protocols)
-        elif parsed_types:
+            for proto_def in parsed_protocols.values():
+                validate_protocol(proto_def, parsed_types)
+
+        if parsed_types:
             gen.generate_types(Path(args.outdir), parsed_types)
-        elif parsed_protocols:
+
+        if parsed_protocols:
             gen.generate_protocols(Path(args.outdir), parsed_protocols)
 
     else:

--- a/messgen-generate.py
+++ b/messgen-generate.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from messgen.validation import validate_protocol
+from messgen.validation import validate_protocol, validate_types
 from messgen import generator, yaml_parser
 from pathlib import Path
 
@@ -31,6 +31,7 @@ def generate(args: argparse.Namespace):
                 validate_protocol(proto_def, parsed_types)
 
         if parsed_types:
+            validate_types(parsed_types)
             gen.generate_types(Path(args.outdir), parsed_types)
 
         if parsed_protocols:

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -9,8 +9,6 @@ from pathlib import (
     Path,
 )
 
-from .validation import validate_protocol
-
 from .common import (
     SEPARATOR,
     SIZE_TYPE,
@@ -124,15 +122,6 @@ class CppGenerator:
         self._includes: set = set()
         self._ctx: dict = {}
         self._types: dict[str, MessgenType] = {}
-
-    def generate(self, out_dir: Path, types: dict[str, MessgenType], protocols: dict[str, Protocol]) -> None:
-        self.validate(types, protocols)
-        self.generate_types(out_dir, types)
-        self.generate_protocols(out_dir, protocols)
-
-    def validate(self, types: dict[str, MessgenType], protocols: dict[str, Protocol]):
-        for proto_def in protocols.values():
-            validate_protocol(proto_def, types)
 
     def generate_types(self, out_dir: Path, types: dict[str, MessgenType]) -> None:
         self._types = types

--- a/messgen/dynamic.py
+++ b/messgen/dynamic.py
@@ -319,7 +319,7 @@ class Codec:
         proto_id, proto = self.types_by_name[proto_name]
         if not type_name in proto:
             raise MessgenError(
-                "Unsupported msg_name in serialization: proto_name=%s msg_name=%s" % (proto_name, type_name))
+                "Unsupported type_name in serialization: proto_name=%s type_name=%s" % (proto_name, type_name))
 
         type_id, type_ = proto[type_name]
         payload = type_.serialize(msg)
@@ -327,17 +327,19 @@ class Codec:
 
     def deserialize(self, proto_id: int, type_id: int, data: bytes) -> tuple[int, str, dict]:
         if not proto_id in self.types_by_id:
-            raise MessgenError("Unsupported proto_id in deserialization: proto_id=%s" % proto_id)
+            raise MessgenError(f"Unsupported proto_id in deserialization: proto_id={proto_id}")
 
         proto_name, proto = self.types_by_id[proto_id]
         if not type_id in proto:
-            raise MessgenError("Unsupported msg_id in deserialization: proto_id=%s msg_id=%s" % (proto_id, type_id))
+            raise MessgenError(f"Unsupported msg_id in deserialization: proto_id={proto_id} type_id={type_id}")
 
         type_name, type_ = proto[type_id]
 
         msg, sz = type_.deserialize(data)
         if sz != len(data):
             raise MessgenError(
-                "Invalid message size: expected=%s actual=%s proto_id=%s msg_id=%s" % (sz, len(data), proto_id, type_id))
+                f"Invalid message size: expected={sz} actual={len(data)} "
+                f"proto_id={proto_id} proto_name={proto_name} "
+                f"type_id={type_id} type_name={type_name}")
 
         return proto_name, type_name, msg

--- a/messgen/json_generator.py
+++ b/messgen/json_generator.py
@@ -25,12 +25,14 @@ class JsonGenerator:
                 continue
             file_name = out_dir / (type_name + self._FILE_EXT)
             file_name.parent.mkdir(parents=True, exist_ok=True)
-            write_file_if_diff(file_name, json.dumps(asdict(type_def), indent=2).splitlines())
+            type_dict = asdict(type_def)
+            type_dict["hash"] = hash(type_def)
+            write_file_if_diff(file_name, json.dumps(type_dict, indent=2).splitlines())
 
     def generate_protocols(self, out_dir: Path, protocols: dict[str, Protocol]) -> None:
         for proto_name, proto_def in protocols.items():
             file_name = out_dir / (proto_name + self._FILE_EXT)
             file_name.parent.mkdir(parents=True, exist_ok=True)
             proto_dict = asdict(proto_def)
-            proto_dict["version"] = version_hash(proto_dict)
-            write_file_if_diff(file_name, json.dumps(asdict(proto_def), indent=2).splitlines())
+            proto_dict["hash"] = hash(proto_def)
+            write_file_if_diff(file_name, json.dumps(proto_dict, indent=2).splitlines())

--- a/messgen/json_generator.py
+++ b/messgen/json_generator.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from .common import write_file_if_diff
 from .protocol_version import version_hash
 
-from .validation import validate_protocol
-
 from .model import (
     MessgenType,
     Protocol,
@@ -20,15 +18,6 @@ class JsonGenerator:
 
     def __init__(self, options):
         self._options = options
-
-    def generate(self, out_dir: Path, types: dict[str, MessgenType], protocols: dict[str, Protocol]) -> None:
-        self.validate(types, protocols)
-        self.generate_types(out_dir, types)
-        self.generate_protocols(out_dir, protocols)
-
-    def validate(self, types: dict[str, MessgenType], protocols: dict[str, Protocol]):
-        for proto_def in protocols.values():
-            validate_protocol(proto_def, types)
 
     def generate_types(self, out_dir: Path, types: dict[str, MessgenType]) -> None:
         for type_name, type_def in types.items():

--- a/messgen/model.py
+++ b/messgen/model.py
@@ -1,6 +1,17 @@
-from dataclasses import dataclass
+import hashlib
+import json
+
+from dataclasses import dataclass, asdict
 from enum import Enum, auto
 from typing import Union
+
+
+def _hash_model_type(dt: dataclass) -> int:
+    input_string = json.dumps(asdict(dt)).replace(" ", "")
+    hash_object = hashlib.md5(input_string.encode())
+    hex_digest = hash_object.hexdigest()
+    hash_32_bits = int(hex_digest[:8], 16)
+    return hash_32_bits
 
 
 class TypeClass(str, Enum):
@@ -20,6 +31,9 @@ class BasicType:
     type_class: TypeClass
     size: int | None
 
+    def __hash__(self):
+        return _hash_model_type(self)
+
 
 @dataclass
 class ArrayType:
@@ -29,6 +43,9 @@ class ArrayType:
     array_size: int
     size: int | None
 
+    def __hash__(self):
+        return _hash_model_type(self)
+
 
 @dataclass
 class VectorType:
@@ -36,6 +53,9 @@ class VectorType:
     type_class: TypeClass
     element_type: str
     size: None
+
+    def __hash__(self):
+        return _hash_model_type(self)
 
 
 @dataclass
@@ -46,12 +66,18 @@ class MapType:
     value_type: str
     size: None
 
+    def __hash__(self):
+        return _hash_model_type(self)
+
 
 @dataclass
 class EnumValue:
     name: str
     value: int
     comment: str
+
+    def __hash__(self):
+        return _hash_model_type(self)
 
 
 @dataclass
@@ -63,12 +89,18 @@ class EnumType:
     values: list[EnumValue]
     size: int
 
+    def __hash__(self):
+        return _hash_model_type(self)
+
 
 @dataclass
 class FieldType:
     name: str
     type: str
     comment: str | None
+
+    def __hash__(self):
+        return _hash_model_type(self)
 
 
 @dataclass
@@ -78,6 +110,9 @@ class StructType:
     comment: str | None
     fields: list[FieldType]
     size: int | None
+
+    def __hash__(self):
+        return _hash_model_type(self)
 
 
 MessgenType = Union[
@@ -95,3 +130,6 @@ class Protocol:
     name: str
     proto_id: int
     types: dict[int, str]
+
+    def __hash__(self):
+        return _hash_model_type(self)

--- a/messgen/model.py
+++ b/messgen/model.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 from typing import Union
 
 
-def _hash_model_type(dt: dataclass) -> int:
+def _hash_model_type(dt) -> int:
     input_string = json.dumps(asdict(dt)).replace(" ", "")
     hash_object = hashlib.md5(input_string.encode())
     hex_digest = hash_object.hexdigest()

--- a/messgen/validation.py
+++ b/messgen/validation.py
@@ -127,6 +127,15 @@ def validate_protocol(protocol: Protocol, types: dict[str, MessgenType]):
             raise RuntimeError(f"Type {type_name} required by {protocol.name} protocol not found")
 
 
+def validate_types(types: dict[str, MessgenType]):
+    seen_hashes = {}
+    for type_name, type_def in types.items():
+        type_hash = hash(type_def)
+        if hash_conflict := seen_hashes.get(type_hash):
+            raise RuntimeError(f"Type {type_name} has the same hash as {hash_conflict.type}")
+        seen_hashes[type_hash] = hash(type_def)
+
+
 # Checks if `s` is a valid name for a field or a message type
 def is_valid_name(name: str):
     if not isinstance(name, str) or not name:

--- a/messgen/validation.py
+++ b/messgen/validation.py
@@ -128,12 +128,12 @@ def validate_protocol(protocol: Protocol, types: dict[str, MessgenType]):
 
 
 def validate_types(types: dict[str, MessgenType]):
-    seen_hashes = {}
+    seen_hashes: dict[int, Any] = {}
     for type_name, type_def in types.items():
         type_hash = hash(type_def)
         if hash_conflict := seen_hashes.get(type_hash):
             raise RuntimeError(f"Type {type_name} has the same hash as {hash_conflict.type}")
-        seen_hashes[type_hash] = hash(type_def)
+        seen_hashes[type_hash] = type_def
 
 
 # Checks if `s` is a valid name for a field or a message type

--- a/tests/python/generate_serialized_data.py
+++ b/tests/python/generate_serialized_data.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     codec.load(type_dirs=['tests/data/types'], protocols=["tests/data/protocols:test_proto", "tests/data/protocols:nested/another_proto"])
 
     # simple_struct
-    t = codec.get_type_by_name("test_proto", "messgen/test/simple_struct")
+    t = codec.get_type_converter("messgen/test/simple_struct")
     msg1: dict[str, Any] = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/simple_struct.bin")
 
     # var_size_struct
-    t = codec.get_type_by_name("test_proto", "messgen/test/var_size_struct")
+    t = codec.get_type_converter("messgen/test/var_size_struct")
     msg1 = {
         "f0": 0x1234567890abcdef,
         "f1_vec": [-0x1234567890abcdef, 5, 1],
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/var_size_struct.bin")
 
     # struct_with_enum
-    t = codec.get_type_by_name("test_proto", "messgen/test/struct_with_enum")
+    t = codec.get_type_converter("messgen/test/struct_with_enum")
     msg1 = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/struct_with_enum.bin")
 
     # empty_struct
-    t = codec.get_type_by_name("test_proto", "messgen/test/empty_struct")
+    t = codec.get_type_converter("messgen/test/empty_struct")
     msg1 = {}
     b = t.serialize(msg1)
     with open('tests/data/serialized/bin/empty_struct.bin', 'wb') as f:
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/empty_struct.bin")
 
     # complex_struct_with_empty
-    t = codec.get_type_by_name("test_proto", "messgen/test/complex_struct_with_empty")
+    t = codec.get_type_converter("messgen/test/complex_struct_with_empty")
     msg1 = {
         "e": {},  # empty_struct
         "dynamic_array": [{} for _ in range(3)],  # list of empty_struct, replace 3 with desired length
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     # complex_struct_nostl
 
-    t = codec.get_type_by_name("test_proto", "messgen/test/complex_struct_nostl")
+    t = codec.get_type_converter("messgen/test/complex_struct_nostl")
     simple_struct = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
 
     # complex_struct
-    t = codec.get_type_by_name("test_proto", "messgen/test/complex_struct")
+    t = codec.get_type_converter("messgen/test/complex_struct")
 
     simple_struct = {
         "f0": 0x1234567890abcdef,
@@ -174,7 +174,7 @@ if __name__ == "__main__":
 
     # flat_struct
 
-    t = codec.get_type_by_name("test_proto", "messgen/test/flat_struct")
+    t = codec.get_type_converter("messgen/test/flat_struct")
     msg1 = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,

--- a/tests/python/generate_serialized_data.py
+++ b/tests/python/generate_serialized_data.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     codec.load(type_dirs=['tests/data/types'], protocols=["tests/data/protocols:test_proto", "tests/data/protocols:nested/another_proto"])
 
     # simple_struct
-    t = codec.get_type_converter("messgen/test/simple_struct")
+    t = codec.get_type_serializer("messgen/test/simple_struct")
     msg1: dict[str, Any] = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/simple_struct.bin")
 
     # var_size_struct
-    t = codec.get_type_converter("messgen/test/var_size_struct")
+    t = codec.get_type_serializer("messgen/test/var_size_struct")
     msg1 = {
         "f0": 0x1234567890abcdef,
         "f1_vec": [-0x1234567890abcdef, 5, 1],
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/var_size_struct.bin")
 
     # struct_with_enum
-    t = codec.get_type_converter("messgen/test/struct_with_enum")
+    t = codec.get_type_serializer("messgen/test/struct_with_enum")
     msg1 = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/struct_with_enum.bin")
 
     # empty_struct
-    t = codec.get_type_converter("messgen/test/empty_struct")
+    t = codec.get_type_serializer("messgen/test/empty_struct")
     msg1 = {}
     b = t.serialize(msg1)
     with open('tests/data/serialized/bin/empty_struct.bin', 'wb') as f:
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     print("Successfully generated serialized data to tests/data/serialized/bin/empty_struct.bin")
 
     # complex_struct_with_empty
-    t = codec.get_type_converter("messgen/test/complex_struct_with_empty")
+    t = codec.get_type_serializer("messgen/test/complex_struct_with_empty")
     msg1 = {
         "e": {},  # empty_struct
         "dynamic_array": [{} for _ in range(3)],  # list of empty_struct, replace 3 with desired length
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     # complex_struct_nostl
 
-    t = codec.get_type_converter("messgen/test/complex_struct_nostl")
+    t = codec.get_type_serializer("messgen/test/complex_struct_nostl")
     simple_struct = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
 
     # complex_struct
-    t = codec.get_type_converter("messgen/test/complex_struct")
+    t = codec.get_type_serializer("messgen/test/complex_struct")
 
     simple_struct = {
         "f0": 0x1234567890abcdef,
@@ -174,7 +174,7 @@ if __name__ == "__main__":
 
     # flat_struct
 
-    t = codec.get_type_converter("messgen/test/flat_struct")
+    t = codec.get_type_serializer("messgen/test/flat_struct")
     msg1 = {
         "f0": 0x1234567890abcdef,
         "f1": 0x1234567890abcdef,

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -11,7 +11,7 @@ def codec():
 
 
 def test_serialization1(codec):
-    type_def = codec.get_type_converter("messgen/test/simple_struct")
+    type_def = codec.get_type_serializer("messgen/test/simple_struct")
     expected_msg = {
         "f0": 0x1234567890abcdef,
         "f2": 1.2345678901234567890,
@@ -31,7 +31,7 @@ def test_serialization1(codec):
 
 
 def test_serialization2(codec):
-    type_def = codec.get_type_converter("messgen/test/var_size_struct")
+    type_def = codec.get_type_serializer("messgen/test/var_size_struct")
     expected_msg = {
         "f0": 0x1234567890abcdef,
         "f1_vec": [-0x1234567890abcdef, 5, 1],

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -11,7 +11,7 @@ def codec():
 
 
 def test_serialization1(codec):
-    type_def = codec.get_type_by_name("test_proto", "messgen/test/simple_struct")
+    type_def = codec.get_type_converter("messgen/test/simple_struct")
     expected_msg = {
         "f0": 0x1234567890abcdef,
         "f2": 1.2345678901234567890,
@@ -32,7 +32,7 @@ def test_serialization1(codec):
 
 
 def test_serialization2(codec):
-    type_def = codec.get_type_by_name("test_proto", "messgen/test/var_size_struct")
+    type_def = codec.get_type_converter("messgen/test/var_size_struct")
     expected_msg = {
         "f0": 0x1234567890abcdef,
         "f1_vec": [-0x1234567890abcdef, 5, 1],

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -25,8 +25,7 @@ def test_serialization1(codec):
     expected_bytes = type_def.serialize(expected_msg)
     assert expected_bytes
 
-    actual_msg, actual_size = type_def.deserialize(expected_bytes)
-    assert actual_size == len(expected_bytes)
+    actual_msg = type_def.deserialize(expected_bytes)
     for key in expected_msg:
         assert actual_msg[key] == pytest.approx(expected_msg[key])
 
@@ -42,6 +41,5 @@ def test_serialization2(codec):
     expected_bytes = type_def.serialize(expected_msg)
     assert expected_bytes
 
-    actual_msg, actual_size = type_def.deserialize(expected_bytes)
-    assert actual_size == len(expected_bytes)
+    actual_msg = type_def.deserialize(expected_bytes)
     assert actual_msg == expected_msg


### PR DESCRIPTION
- compute 32 bit hashes for each type schema
- expose generated hashes in dynamic, json and cpp
- improve formatting of the generated cpp code
- allow looking up specific dynamic serializer by type

The introduction schema hash (TYPE::HASH in C++, 
serializer.type_hash() in Python and ["hash"] in json)
is dictated by the need to support type consistency
checks of serialized messages. 

Since the extraction of types from protocols the latter 
became just logical grouping of types. In fact the name
or id of the protocol is not needed to successfully 
serialize / deserialize a message. 